### PR TITLE
Add wheel sensor module

### DIFF
--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -15,8 +15,6 @@ try:
 except:
     raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-from extras.wheel_sensor import StandaloneWheelSensor
-import time
 
 #LED
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
@@ -255,10 +253,19 @@ class AFCExtruderStepper:
 
         # 4) Continue rewinding until RPM < baseline * drop_fraction
         cutoff = baseline_rpm * self.tension_drop_fraction
+        target_rpm = baseline_rpm
         while (self.reactor.monotonic() - start_time) < self.tension_max_time:
             wheel_rpm, motor_rpm = sensor.get_rpm()
-            if wheel_rpm is not None and wheel_rpm < cutoff:
-                break
+            if wheel_rpm is not None:
+                # Adjust PWM to keep wheel RPM near the target
+                if wheel_rpm < target_rpm * 0.9:
+                    pwm_val = max(pwm_val - 0.05, -1.0)
+                    self.assist(pwm_val)
+                elif wheel_rpm > target_rpm * 1.1:
+                    pwm_val = min(pwm_val + 0.05, 0.0)
+                    self.assist(pwm_val)
+                if wheel_rpm < cutoff:
+                    break
             self.reactor.pause(self.reactor.monotonic() + 0.1)
 
         # 5) Stop the respooler

--- a/extras/wheel_sensor.py
+++ b/extras/wheel_sensor.py
@@ -1,0 +1,53 @@
+# Armored Turtle Automated Filament Changer
+# Wheel sensor module for RPM feedback
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+"""Standalone hall effect wheel sensor implementation."""
+
+from configfile import error
+
+
+def load_config(config):
+    """Entry point for Klipper to load the wheel sensor."""
+    return StandaloneWheelSensor(config)
+
+
+class StandaloneWheelSensor:
+    """Simple hall-effect based wheel RPM sensor."""
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.name = config.get_name().split()[-1]
+        self.pulses_per_rev = config.getfloat("pulses_per_rev", 1.0, minval=0.1)
+        self.pin = config.get("pin")
+        if self.pin is None:
+            raise error(f"wheel_sensor {self.name}: pin must be specified")
+
+        # pulse counter and timestamp for rpm calculation
+        self._pulse_count = 0
+        self._prev_state = 0
+        self._last_time = self.reactor.monotonic()
+
+        buttons = self.printer.load_object(config, "buttons")
+        buttons.register_buttons([self.pin], self._edge_callback)
+
+    def _edge_callback(self, eventtime, state):
+        # count rising edges
+        if not self._prev_state and state:
+            self._pulse_count += 1
+        self._prev_state = state
+
+    def get_rpm(self):
+        """Return tuple of (wheel_rpm, motor_rpm)."""
+        now = self.reactor.monotonic()
+        dt = now - self._last_time
+        if dt <= 0:
+            return None, None
+        pulses = self._pulse_count
+        self._pulse_count = 0
+        self._last_time = now
+        rpm = (pulses / self.pulses_per_rev) / dt * 60.0
+        return rpm, rpm


### PR DESCRIPTION
## Summary
- add a standalone hall-effect wheel sensor module
- tune tension-based rewind to adjust PWM based on measured RPM

## Testing
- `ruff check extras/wheel_sensor.py extras/AFC_stepper.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4414fcd083248131aa9579f27cd1